### PR TITLE
Fix isochrone file naming

### DIFF
--- a/R/01-setup.R
+++ b/R/01-setup.R
@@ -552,7 +552,15 @@ process_and_save_isochrones <- function(input_file, chunk_size = 25,
       # Create the file name with the current date and time
       current_datetime <- format(Sys.time(), "%Y%m%d%H%M%S")
 
-      file_name <- paste(file_path_prefix, current_datetime, "_chunk_", min(chunk_data$id), "_to_", max(chunk_data$id))
+      file_name <- paste0(
+        file_path_prefix,
+        current_datetime,
+        "_chunk_",
+        min(chunk_data$id),
+        "_to_",
+        max(chunk_data$id)
+      )
+      dir.create(file_name, recursive = TRUE, showWarnings = FALSE)
 
       # Assuming "arrival" field is originally in character format with both date and time
       # Convert it to a DateTime object


### PR DESCRIPTION
## Summary
- fix file path generation in `process_and_save_isochrones`
- ensure target directory exists when writing shapefiles

## Testing
- `Rscript tests/testthat.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de9d9cf80832c9f70f78b2c5a520b