### PR TITLE
Refactor repeated HERE API setup into helper

### DIFF
--- a/R/01-setup.R
+++ b/R/01-setup.R
@@ -55,6 +55,7 @@ library(ggplot2)
 library(ggthemes)
 library(maps)
 library(forcats)
+source("R/here_api_utils.R")
 
 #Of note this is a personal package with some bespoke functions and data that we will use occasionally.  It is still under development and it is normal for it to give multiple warnings at libary(tyler).
 # devtools::install_github("mufflyt/tyler")
@@ -63,9 +64,7 @@ library(forcats)
 # Store tidycensus data on cache
 options(tigris_use_cache = TRUE)
 
-Sys.setenv(HERE_API_KEY = "VnDX-Rafqchcmb4LUDgEpYlvk8S1-LCYkkrtb1ujOrM")
-readRenviron("~/.Renviron")
-hereR::set_key("VnDX-Rafqchcmb4LUDgEpYlvk8S1-LCYkkrtb1ujOrM")
+initialize_here_api_key("VnDX-Rafqchcmb4LUDgEpYlvk8S1-LCYkkrtb1ujOrM")
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 #####  Directory structure with here
@@ -302,8 +301,7 @@ search_and_process_npi <- memoise(function(input_file,
 #**************************
 create_geocode <- memoise::memoise(function(csv_file) {
   # Set your HERE API key
-  api_key <- "VnDX-Rafqchcmb4LUDgEpYlvk8S1-LCYkkrtb1ujOrM"
-  hereR::set_key(api_key)
+  initialize_here_api_key("VnDX-Rafqchcmb4LUDgEpYlvk8S1-LCYkkrtb1ujOrM")
 
   # Check if the CSV file exists
   if (!file.exists(csv_file)) {

--- a/R/here_api_utils.R
+++ b/R/here_api_utils.R
@@ -1,0 +1,7 @@
+initialize_here_api_key <- function(api_key = Sys.getenv("HERE_API_KEY")) {
+  if (is.null(api_key) || api_key == "") {
+    stop("HERE API key must be provided via argument or HERE_API_KEY env var.")
+  }
+  Sys.setenv(HERE_API_KEY = api_key)
+  hereR::set_key(api_key)
+}

--- a/geocode.R
+++ b/geocode.R
@@ -32,12 +32,12 @@
 #' @import dplyr
 #'
 #' @export
+source("R/here_api_utils.R")
 #'
 
 create_geocode <- function(csv_file, output_file) {
   # Set your HERE API key
-  api_key <- "VnDX-Rafqchcmb4LUDgEpYlvk8S1-LCYkkrtb1ujOrM"
-  hereR::set_key(api_key)
+  initialize_here_api_key("VnDX-Rafqchcmb4LUDgEpYlvk8S1-LCYkkrtb1ujOrM")
 
   # Check if the CSV file exists
   if (!file.exists(csv_file)) {


### PR DESCRIPTION
## Summary
- add `initialize_here_api_key()` helper
- use helper in setup and geocode scripts

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed636f468832cb63ace8c028d24a8