### PR TITLE
Fix NA filling functions

### DIFF
--- a/R/expand_and_fill_years.R
+++ b/R/expand_and_fill_years.R
@@ -16,8 +16,8 @@ expand_and_fill_years <- function(input_data, start_year = 2008, end_year = 2023
       lastupdatestr = ifelse(year >= lastupdatestr, lastupdatestr, NA_integer_),
       penumdatestr = ifelse(year >= penumdatestr, penumdatestr, NA_integer_)
     ) %>%
-    fill(lastupdatestr, penumdatestr, pfname, plname, address, plocline1, ploccityname,
-         plocstatename, ploczip, ploctel, pmailline1, .direction = "down") %>%  # Fill values down to subsequent years
+    tidyr::fill(lastupdatestr, penumdatestr, pfname, plname, address, plocline1, ploccityname,
+                plocstatename, ploczip, ploctel, pmailline1, .direction = "down") %>%  # Fill values down to subsequent years
     ungroup()
   
   # Keep only one unique record per NPI per year
@@ -67,12 +67,12 @@ transform_to_fill_in_correct <- function(input_data, start_year = 2008, end_year
     tidyr::expand(., npi, year = year_sequence) %>%
     dplyr::left_join(input_data, by = c("npi", "year" = "lastupdatestr")) %>% # Join back the original data
     dplyr::group_by(npi) %>%
-    fill(everything(), .direction = "down") %>%
+    tidyr::fill(everything(), .direction = "down") %>%
     # Ensure there is one distinct row per npi, year, lastupdatestr
     dplyr::distinct(., .keep_all = TRUE) %>%
     dplyr::ungroup() %>%
     # Replace remaining NAs with "unknown"
-    dplyr::mutate(across(c(address, plocline1, ploccityname, plocstatename, ploczip, ploctel), ~replace_na(., "unknown")))
+    dplyr::mutate(across(c(address, plocline1, ploccityname, plocstatename, ploczip, ploctel), ~tidyr::replace_na(., "unknown")))
   
   return(expanded_data)
 }

--- a/R/zztoy example.R
+++ b/R/zztoy example.R
@@ -28,7 +28,7 @@ dataframe_final <- expanded_df %>%
     lastupdatestr = if_else(year >= lastupdatestr, lastupdatestr, NA_real_),
     is_update = if_else(is.na(lag(lastupdatestr)) | lastupdatestr != lag(lastupdatestr), TRUE, FALSE)
   ) %>%
-  fill(everything(), .direction = "down") %>%
+  tidyr::fill(everything(), .direction = "down") %>%
   filter(is_update) %>%
   select(-is_update) %>%
   ungroup() %>%

--- a/R/zztoy_data_set.R
+++ b/R/zztoy_data_set.R
@@ -30,11 +30,11 @@ dataframe_final <- expanded_df %>%
   mutate(
     is_update = if_else(is.na(lag(lastupdatestr)) | lastupdatestr != lag(lastupdatestr), TRUE, FALSE),
     # Fill NA values for character and numeric columns to ensure no data gaps.
-    across(where(is.character), ~replace_na(., "")),
-    across(where(is.numeric), ~replace_na(., 0))
+    across(where(is.character), ~tidyr::replace_na(., "")),
+    across(where(is.numeric), ~tidyr::replace_na(., 0))
   ) %>%
   # Propagate the last known values downward to fill gaps in data.
-  fill(everything(), .direction = "down") %>%
+  tidyr::fill(everything(), .direction = "down") %>%
   # Only retain rows marked as updates to reduce data redundancy.
   filter(is_update) %>%
   select(-is_update) %>%


### PR DESCRIPTION
## Summary
- namespaced calls to `fill()` and `replace_na()` in helper scripts
- ensure tidyr is used explicitly for filling missing values

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684edcbe6eb0832c94068718a2eb53ca