### PR TITLE
Fix small bugs in helper scripts

### DIFF
--- a/R/01-setup.R
+++ b/R/01-setup.R
@@ -215,10 +215,12 @@ search_and_process_npi <- memoise(function(input_file,
 
   # Check if the input file exists
   if (!file.exists(input_file)) {
-    stop(
-      "The specified file with the NAMES to search'", input_file, "' does not exist.\n",
+    stop(paste0(
+      "The specified file with the NAMES to search '",
+      input_file,
+      "' does not exist.\n",
       "Please provide the full path to the file."
-    )
+    ))
   }
   cat("Input file found.\n")
 

--- a/R/1000_intern_search.R
+++ b/R/1000_intern_search.R
@@ -10,10 +10,12 @@ search_and_process_npi <- memoise(function(input_file,
 
   # Check if the input file exists
   if (!file.exists(input_file)) {
-    stop(
-      "The specified file with the NAMES to search'", input_file, "' does not exist.\n",
+    stop(paste0(
+      "The specified file with the NAMES to search '",
+      input_file,
+      "' does not exist.\n",
       "Please provide the full path to the file."
-    )
+    ))
   }
   cat("Input file found.\n")
 

--- a/R/expand_and_fill_years.R
+++ b/R/expand_and_fill_years.R
@@ -1,3 +1,6 @@
+# Needed for message formatting
+library(glue)
+
 expand_and_fill_years <- function(input_data, start_year = 2008, end_year = 2023) {
   # Log the function call with arguments
   message(glue::glue("Function expand_and_fill_years called with start_year: {start_year}, end_year: {end_year}"))

--- a/R/zz05-geocode-cleaning.R
+++ b/R/zz05-geocode-cleaning.R
@@ -145,7 +145,7 @@ leaflet::leaflet(data = inner_join_postmastr_clinician_data) %>%
   # Add ACOG district boundaries
   leaflet::addPolygons(
     data = acog_districts_sf,
-    color = district_colors[as.numeric(inner_join_postmastr_clinician_data$ACOG_District)],      # Boundary color
+    color = district_colors[as.numeric(acog_districts_sf$ACOG_District)],      # Boundary color
     weight = 2,         # Boundary weight
     fill = TRUE,       # No fill
     opacity = 0.1,      # Boundary opacity
@@ -154,7 +154,7 @@ leaflet::leaflet(data = inner_join_postmastr_clinician_data) %>%
   #Add a legend
   leaflet::addLegend(
     position = "bottomright",   # Position of the legend on the map
-    colors = district_colors,   # Colors for the legend
-    labels = levels(inner_join_postmastr_clinician_data$ACOG_District),   # Labels for legend items
-    title = "ACOG Districts"   # Title for the legend
+    colors = district_colors,
+    labels = levels(factor(acog_districts_sf$ACOG_District)),
+    title = "ACOG Districts"
   )


### PR DESCRIPTION
## Summary
- load `glue` in `expand_and_fill_years.R`
- fix incorrect quoting in intern search helpers
- correct leaflet legend setup for district map

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edcd9c260832c91a62b891c55947a