### PR TITLE
Fix typos in R helper scripts

### DIFF
--- a/R/R_from_tyler_package/calculate_intersection_overlap_and_save.R
+++ b/R/R_from_tyler_package/calculate_intersection_overlap_and_save.R
@@ -34,7 +34,7 @@ calculate_intersection_overlap_and_save <- function(block_groups, isochrones_joi
   }
 
   # Filter isochrones for the specified drive time
-  isochrones_filtered <- sf::filter(isochrones_joined, drive_time == drive_time)
+  isochrones_filtered <- dplyr::filter(isochrones_joined, drive_time == drive_time)
 
   # Calculate intersection
   intersect <- sf::st_intersection(block_groups, isochrones_filtered) %>%

--- a/R/R_from_tyler_package/create_individual_isochrone_plots.R
+++ b/R/R_from_tyler_package/create_individual_isochrone_plots.R
@@ -53,7 +53,7 @@ create_individual_isochrone_plots <- function(isochrones, drive_times) {
     # Filter isochrones for the specified drive time
     isochrones_filtered <- dplyr::filter(isochrones, drive_time == time)
 
-    # Combine fuck isochrones using st_union
+    # Combine isochrones using st_union
     isochrones_combined <- sf::st_union(isochrones_filtered)
 
     # Create an sf object with the combined isochrones

--- a/R/R_from_tyler_package/this_one_works.R
+++ b/R/R_from_tyler_package/this_one_works.R
@@ -23,6 +23,9 @@ scrape_physicians_data_with_tor <- function(startID, endID, torPort) {
   cat("Starting scrape_physicians_data_with_tor...\n")
   cat("Parameters - startID:", startID, "endID:", endID, "torPort:", torPort, "\n")
 
+  # Directory for temporary output files
+  temp_dir <- tempdir()
+
   # Create a sequence of IDs from startID to endID
   id_list <- seq(startID, endID)
   cat("ID list:", paste(id_list, collapse = ", "), "\n")
@@ -56,7 +59,7 @@ scrape_physicians_data_with_tor <- function(startID, endID, torPort) {
     cat("API URL:", url, "\n")
 
     # Send a GET request through Tor
-    ph_r <- httr::GET(url, use_proxy(paste0("socks5://localhost:", torPort)))
+    ph_r <- httr::GET(url, httr::use_proxy(paste0("socks5://localhost:", torPort)))
 
     # Check if the request was successful
     if (ph_r$status_code == 200) {


### PR DESCRIPTION
## Summary
- fix `sf::filter` call to use dplyr in `calculate_intersection_overlap_and_save`
- clean up comment in `create_individual_isochrone_plots`
- add temp dir setup and qualify proxy helper in `this_one_works`

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee12cd208832ca46324d6cbee26b4