### PR TITLE
Fix format_pct default digits

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -6,5 +6,5 @@
 #' @examples
 #' format_pct(0.1234, my_digits = 2)
 format_pct <- function(x, my_digits = 0) {
-  format(x, digits = my_digits, nsmall = my_digits)
+  formatC(x, format = "f", digits = my_digits)
 }


### PR DESCRIPTION
## Summary
- fix `format_pct()` so default `my_digits=0` doesn't cause an error

## Testing
- `Rscript -e 'source("R/formatting.R"); if (format_pct(0.1234, my_digits=2) != "0.12") quit(status=1)'`
- `Rscript -e 'source("R/formatting.R"); if (format_pct(0.1234) != "0") quit(status=1)'`


------
https://chatgpt.com/codex/tasks/task_e_684f65950f30832c89b62b002eb381ba