### PR TITLE
Add verbose flag to utilities

### DIFF
--- a/R/api_utils.R
+++ b/R/api_utils.R
@@ -3,16 +3,27 @@
 #'
 #' @param var Name of the environment variable
 #' @param msg Optional custom message
+#' @param verbose Logical. If TRUE, log additional information.
 #' @return The value of the environment variable
 #' @examples
 #' api_key <- get_env_or_stop("HERE_API_KEY")
-get_env_or_stop <- function(var, msg = NULL) {
+get_env_or_stop <- function(var, msg = NULL, verbose = FALSE) {
+  if (verbose) {
+    logger::log_info("Retrieving environment variable '%s'", var)
+  }
+
   val <- Sys.getenv(var)
+
   if (val == "") {
     if (is.null(msg)) {
       msg <- paste0(var, " environment variable is not set. Please add it to your .Renviron or .env file")
     }
     stop(msg, call. = FALSE)
   }
+
+  if (verbose) {
+    logger::log_info("Successfully retrieved environment variable '%s'", var)
+  }
+
   val
 }

--- a/R/here_api_utils.R
+++ b/R/here_api_utils.R
@@ -1,7 +1,17 @@
-initialize_here_api_key <- function(api_key = Sys.getenv("HERE_API_KEY")) {
+#' Initialize HERE API Key
+#'
+#' @param api_key Character. The HERE API key. Defaults to `HERE_API_KEY` env var.
+#' @param verbose Logical. If TRUE, log additional information.
+#' @export
+initialize_here_api_key <- function(api_key = Sys.getenv("HERE_API_KEY"), verbose = FALSE) {
   if (is.null(api_key) || api_key == "") {
     stop("HERE API key must be provided via argument or HERE_API_KEY env var.")
   }
+
   Sys.setenv(HERE_API_KEY = api_key)
   hereR::set_key(api_key)
+
+  if (verbose) {
+    logger::log_info("HERE API key successfully initialized")
+  }
 }

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ accessibility over time and retirement patterns among specialists.
 -   Gynecologic Oncology
 -   Maternal-Fetal Medicine
 -   Reproductive Endocrinology and Infertility
+-   Most helper functions include a `verbose` argument to control logging. Set it to `FALSE` for quieter execution.
 
 ## Materials and Methods
 


### PR DESCRIPTION
## Summary
- support `verbose` flag in `get_env_or_stop`
- add optional logging to HERE API key initialization
- note verbose option in documentation

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858abc567f4832c9030272a77b2681e