### PR TITLE
Fix csv_file variable issue in 04-geocode script

### DIFF
--- a/R/04-geocode.R
+++ b/R/04-geocode.R
@@ -413,12 +413,17 @@ obgyn_geocoding_data <- prepare_addresses_for_geocoding(
 )
 
 #**************************
-#* GEOCODE THE DATA USING HERE API.  The key is hard coded into the function.  
+#* GEOCODE THE DATA USING HERE API.  The key is hard coded into the function.
 #**************************
 
+# Define the CSV file path before calling `create_geocode`
+csv_file <- "data/geocoding/obgyn_practice_addresses_for_geocoding.csv"
 
 geocoded_data <- create_geocode(csv_file)
-readr::write_csv(geocoded_data, "data/04-geocode/end_completed_clinician_data_geocoded_addresses_12_8_2023.csv")
+readr::write_csv(
+  geocoded_data,
+  "data/04-geocode/end_completed_clinician_data_geocoded_addresses_12_8_2023.csv"
+)
 
 # Geocoding Using HERE API ----
 #'
@@ -790,7 +795,6 @@ geocoding_using_HERE_API <- function(csv_file_path,
 }
 
 # Execute ----
-csv_file <- "data/geocoding/obgyn_practice_addresses_for_geocoding.csv"
 
 read_csv(csv_file)
 

--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,13 @@ critical for spatial accuracy in healthcare accessibility analysis.
 
 *Source: `R/04-geocode.R`*
 
+Example usage:
+
+```r
+csv_file <- "data/geocoding/obgyn_practice_addresses_for_geocoding.csv"
+geocoded_data <- create_geocode(csv_file)
+```
+
 
 
 ### Why Full Addresses vs. ZIP Code Geocoding

--- a/tests/testthat/test-format-pct.R
+++ b/tests/testthat/test-format-pct.R
@@ -1,4 +1,5 @@
 library(testthat)
+source(file.path("..", "..", "R", "formatting.R"))
 
 test_that("format_pct rounds and formats numbers", {
   expect_equal(format_pct(0.1234, my_digits = 2), "0.12")


### PR DESCRIPTION
## Summary
- define `csv_file` before `create_geocode` is called
- remove duplicate variable later in the file
- document example usage in README
- source formatting helper in tests so unit tests pass

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_6858a823d1b8832cbdcaf252c459fcf1