### PR TITLE
Fix duplicate function definition

### DIFF
--- a/R/01-setup.R
+++ b/R/01-setup.R
@@ -722,12 +722,6 @@ download_and_merge_block_groups <- function(year) {
 # Example usage: download data for the year 2020
 # combined_block_groups_2020 <- download_and_merge_block_groups(2020)
 
-##########
-format_pct <- function(x, my_digits = 0) {
-  format(x, digits = my_digits, nsmall = my_digits)
-}
-
-
 #########
 postico_database_obgyns_by_year <- function(year, db_details) {
   # Database connection details


### PR DESCRIPTION
## Summary
- remove duplicate `format_pct` helper from `R/01-setup.R`
- keep single implementation in `R/formatting.R`

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b657375c832cab03edca59cbdde2