### PR TITLE
Introduce safe log formatter

### DIFF
--- a/R/bespoke_functions.R
+++ b/R/bespoke_functions.R
@@ -2864,6 +2864,7 @@ process_physician_retirement <- function(data_directory,
 initialize_logger <- function(verbose) {
   log_level <- if (verbose) "DEBUG" else "INFO"
   logger::log_threshold(log_level)
+  logger::log_formatter(formatter_glue_safe)
   logger::log_info("Logger initialized with level: {log_level}")
 }
 

--- a/R/logger_utils.R
+++ b/R/logger_utils.R
@@ -1,0 +1,14 @@
+#' Safe glue-based log formatter
+#'
+#' Uses `glue::glue` for string interpolation but falls back to the
+#' raw message if interpolation fails. This prevents logging from
+#' aborting when variables referenced in braces are missing.
+formatter_glue_safe <- function(...,
+                               .logcall = sys.call(),
+                               .topcall = sys.call(-1),
+                               .topenv = parent.frame()) {
+  tryCatch(
+    glue::glue(..., .envir = .topenv),
+    error = function(e) paste0(...)
+  )
+}


### PR DESCRIPTION
## Summary
- add `formatter_glue_safe` to avoid logger errors when variables are missing
- initialize logging with the safe formatter

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_6858b5f8033c832c9e1fcd4e7419ea6a