### PR TITLE
Fix isochrone save path handling

### DIFF
--- a/R/01-setup.R
+++ b/R/01-setup.R
@@ -526,12 +526,12 @@ test_and_process_isochrones <- function(input_file) {
 
 ##############################
 ###############################
-process_and_save_isochrones <- function(input_file, chunk_size = 25, 
+process_and_save_isochrones <- function(input_file, chunk_size = 25,
                                         iso_datetime = "2023-10-20 09:00:00",
                                         iso_ranges = c(30*60, 60*60, 120*60, 180*60),
-                                        crs = 4326, 
+                                        crs = 4326,
                                         transport_mode = "car",
-                                        file_path_prefix = "data/06-isochrones/isochrones_") 
+                                        save_dir = "data/06-isochrones")
   {
   message("Starting isochrones processing...")
   input_file$lat <- as.numeric(input_file$lat)
@@ -577,13 +577,18 @@ process_and_save_isochrones <- function(input_file, chunk_size = 25,
       # Create the file name with the current date and time
       current_datetime <- format(Sys.time(), "%Y%m%d%H%M%S")
 
-      file_name <- paste0(
-        file_path_prefix,
-        current_datetime,
-        "_chunk_",
-        min(chunk_data$id),
-        "_to_",
-        max(chunk_data$id)
+      dir.create(save_dir, recursive = TRUE, showWarnings = FALSE)
+
+      file_name <- file.path(
+        save_dir,
+        paste0(
+          "isochrones_",
+          current_datetime,
+          "_chunk_",
+          min(chunk_data$id),
+          "_to_",
+          max(chunk_data$id)
+        )
       )
       dir.create(file_name, recursive = TRUE, showWarnings = FALSE)
 

--- a/R/06-isochrones.R
+++ b/R/06-isochrones.R
@@ -50,7 +50,6 @@ nrow(input_file_no_error_rows) * 4
 # non-spatial join
 #(iso_attr <- st_sf(merge(as.data.frame(poi), iso,  by = "id", all = TRUE)))
 
-# TODO I need to fix the process_and_save_isochrones function to give it a path to save.
 # Call the `process_and_save_isochrones` function with your input_file
 iso_datetime_yearly <- c("2013-10-18 09:00:00", "2014-10-17 09:00:00", "2015-10-16 09:00:00",
   "2016-10-21 09:00:00", "2017-10-20 09:00:00", "2018-10-19 09:00:00",
@@ -62,9 +61,9 @@ isochrones_sf <- process_and_save_isochrones(input_file_no_error_rows,
                                              chunk_size = 25, 
                                              iso_datetime = as.POSIXct("2023-10-20 09:00:00"),
                                              iso_ranges = c(30*60, 60*60, 120*60, 180*60),
-                                             crs = 4326, 
+                                             crs = 4326,
                                              transport_mode = "car",
-                                             file_path_prefix = "data/06-isochrones/isochrones_")
+                                             save_dir = "data/06-isochrones")
 
 # Check the dimensions of the final isochrones_data
 dim(isochrones_sf)

--- a/README.md
+++ b/README.md
@@ -1245,7 +1245,7 @@ isochrones_sf <- process_and_save_isochrones(
   iso_ranges = c(30*60, 60*60, 120*60, 180*60),  # Convert minutes to seconds
   crs = 4326, 
   transport_mode = "car",
-  file_path_prefix = "data/06-isochrones/isochrones_"
+  save_dir = "data/06-isochrones"
 )
 ```
 

--- a/README.rmd
+++ b/README.rmd
@@ -1220,7 +1220,7 @@ isochrones_sf <- process_and_save_isochrones(
   iso_ranges = c(30*60, 60*60, 120*60, 180*60),  # Convert minutes to seconds
   crs = 4326, 
   transport_mode = "car",
-  file_path_prefix = "data/06-isochrones/isochrones_"
+  save_dir = "data/06-isochrones"
 )
 ```
 


### PR DESCRIPTION
## Summary
- let `process_and_save_isochrones()` accept a `save_dir` parameter
- use the new argument from the isochrone workflow script
- document example usage with `save_dir`

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_6858b642d5b0832ca48919970ea9a625