### PR TITLE
Use explicit namespaces in tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -6,7 +6,5 @@
 # * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
 # * https://testthat.r-lib.org/articles/special-files.html
 
-library(testthat)
-
 # There is no installed isochrones package. Run tests directly from this folder.
 testthat::test_dir("testthat")

--- a/tests/testthat/test-abstract_stats.R
+++ b/tests/testthat/test-abstract_stats.R
@@ -1,11 +1,10 @@
-library(testthat)
 source(file.path("..", "..", "R", "abstract_statistics.R"))
 
 
-test_that("summarize_abstract counts correctly", {
+testthat::test_that("summarize_abstract counts correctly", {
   text <- "Hello world. This is a test!"
   res <- summarize_abstract(text)
-  expect_equal(res$words, 6)
-  expect_equal(res$sentences, 2)
-  expect_equal(res$characters, nchar(text))
+  testthat::expect_equal(res$words, 6)
+  testthat::expect_equal(res$sentences, 2)
+  testthat::expect_equal(res$characters, nchar(text))
 })

--- a/tests/testthat/test-format-pct.R
+++ b/tests/testthat/test-format-pct.R
@@ -1,6 +1,5 @@
-library(testthat)
 source(file.path("..", "..", "R", "formatting.R"))
 
-test_that("format_pct rounds and formats numbers", {
-  expect_equal(format_pct(0.1234, my_digits = 2), "0.12")
+testthat::test_that("format_pct rounds and formats numbers", {
+  testthat::expect_equal(format_pct(0.1234, my_digits = 2), "0.12")
 })


### PR DESCRIPTION
## Summary
- avoid loading testthat
- reference testthat functions with the `testthat::` namespace

## Testing
- `R -q -e "source('tests/testthat.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858bdc787f0832c97dc6642b1fe9c5d