### PR TITLE
Move sleep call before returns

### DIFF
--- a/@deprecated/R/zzzPostico.R
+++ b/@deprecated/R/zzzPostico.R
@@ -248,16 +248,18 @@ retrieve_clinician_data <- function(input_data) {
   get_clinician_data <- function(npi) {
     if (!is.numeric(npi) || nchar(npi) != 10) {
       cat("Invalid NPI:", npi, "\n")
+      Sys.sleep(1)
       return(NULL)  # Skip this NPI
     }
-    
+
     clinician_info <- provider::clinicians(npi = npi)
     if (is.null(clinician_info)) {
       cat("No results for NPI:", npi, "\n")
+      Sys.sleep(1)
     } else {
+      Sys.sleep(1)
       return(clinician_info)  # Print the clinician data as it comes out
     }
-    Sys.sleep(1)
   }
   
   #df <- df %>% head(5) #test

--- a/R/01-setup.R
+++ b/R/01-setup.R
@@ -840,6 +840,7 @@ retrieve_clinician_data <- function(input_data, no_results_csv = "no_results_npi
   get_clinician_data <- function(npi) {
     if (!is.numeric(npi) || nchar(npi) != 10) {
       cat("Invalid NPI:", npi, "\n")
+      Sys.sleep(1)  # To avoid rate limits in API calls
       return(NULL)  # Skip this NPI
     }
 
@@ -847,11 +848,12 @@ retrieve_clinician_data <- function(input_data, no_results_csv = "no_results_npi
     if (is.null(clinician_info)) {
       cat("No results for NPI:", npi, "\n")
       no_results_npi <<- c(no_results_npi, list(npi))  # Add the NPI to the list
+      Sys.sleep(1)  # To avoid rate limits in API calls
       return(NULL)
     } else {
+      Sys.sleep(1)  # To avoid rate limits in API calls
       return(clinician_info)  # Return the clinician data
     }
-    Sys.sleep(1)  # To avoid rate limits in API calls
   }
   
   # Loop through the NPI column and get clinician data


### PR DESCRIPTION
## Summary
- ensure `Sys.sleep()` executes before every `return` in `get_clinician_data`

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858c3af8ecc832ca33327cf86e3b642