### PR TITLE
Fix HERE API key setup order

### DIFF
--- a/R/01-setup.R
+++ b/R/01-setup.R
@@ -64,10 +64,10 @@ source("R/here_api_utils.R")
 # Store tidycensus data on cache
 options(tigris_use_cache = TRUE)
 
+readRenviron("~/.Renviron")
 if (!nzchar(Sys.getenv("HERE_API_KEY"))) {
   stop("HERE_API_KEY environment variable is not set.")
 }
-readRenviron("~/.Renviron")
 hereR::set_key(Sys.getenv("HERE_API_KEY"))
 
 

--- a/R/R_from_tyler_package/create_isochrones.R
+++ b/R/R_from_tyler_package/create_isochrones.R
@@ -32,10 +32,10 @@
 #' @importFrom hereR set_freemium set_key set_verbose isoline
 create_isochrones <- memoise::memoise(function(location, range, posix_time = as.POSIXct("2023-10-20 08:00:00", format = "%Y-%m-%d %H:%M:%S")) {
 
+  readRenviron("~/.Renviron")
   if (!nzchar(Sys.getenv("HERE_API_KEY"))) {
     stop("HERE_API_KEY environment variable is not set.")
   }
-  readRenviron("~/.Renviron")
   hereR::set_key(Sys.getenv("HERE_API_KEY"))
 
 

--- a/R/R_from_tyler_package/create_isochrones_for_dataframe.R
+++ b/R/R_from_tyler_package/create_isochrones_for_dataframe.R
@@ -18,10 +18,10 @@ create_isochrones_for_dataframe <- function(input_file, breaks = c(1800, 3600, 7
   #input_file <- "_Recent_Grads_GOBA_NPI_2022a.rds" #for testing;
   #input_file <- "data/test_short_inner_join_postmastr_clinician_data_sf.csv"
 
+  readRenviron("~/.Renviron")
   if (!nzchar(Sys.getenv("HERE_API_KEY"))) {
     stop("HERE_API_KEY environment variable is not set.")
   }
-  readRenviron("~/.Renviron")
   hereR::set_key(Sys.getenv("HERE_API_KEY"))
 
 


### PR DESCRIPTION
## Summary
- load `.Renviron` before checking for the HERE API key
- only stop if the key remains unset after loading the environment file

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c39e38d0832c99d2843968f5546f