### PR TITLE
Add codemeta file

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "name": "Gynecologic Oncology Accessibility Project",
+  "description": "Helper functions for isochrone-based analysis of gynecologic oncology accessibility across the United States.",
+  "license": "https://opensource.org/licenses/MIT",
+  "version": "0.1.0",
+  "datePublished": "2025-06-22",
+  "codeRepository": "https://github.com/mufflyt/isochrones",
+  "issueTracker": "https://github.com/mufflyt/isochrones/issues",
+  "programmingLanguage": "R",
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Tyler",
+      "familyName": "Muffly",
+      "email": "tyler.muffly@dhha.org",
+      "affiliation": {
+        "@type": "Organization",
+        "name": "Department of Obstetrics and Gynecology"
+      }
+    }
+  ],
+  "keywords": [
+    "gynecologic oncology",
+    "healthcare accessibility",
+    "spatial analysis",
+    "isochrones",
+    "health disparities",
+    "geographic information systems"
+  ]
+}


### PR DESCRIPTION
## Summary
- add codemeta.json with project metadata for software citation

## Testing
- `R -e "testthat::test_dir('tests/testthat')"` *(fails: '\\s' is an unrecognized escape in abstract statistics)*

------
https://chatgpt.com/codex/tasks/task_e_6858c33ce054832caa3c7f9741fb9549