### PR TITLE
Add compute before collect steps

### DIFF
--- a/R/B-nber_nppes_combine_columns.R
+++ b/R/B-nber_nppes_combine_columns.R
@@ -1759,6 +1759,7 @@ final_dataset_statistics <- final_processed_obgyn_providers %>%
     md_credential_count = sum(credential_standardized == "MD", na.rm = TRUE),
     do_credential_count = sum(credential_standardized == "DO", na.rm = TRUE)
   ) %>%
+  dplyr::compute() %>%
   dplyr::collect()
 
 logger::log_info("=== FINAL DATASET STATISTICS ===")
@@ -1771,6 +1772,7 @@ logger::log_info("DO credentials: {final_dataset_statistics$do_credential_count}
 logger::log_info("Collecting final processed dataset from duckplyr to R memory")
 
 final_obgyn_provider_dataset <- final_processed_obgyn_providers %>%
+  dplyr::compute() %>%
   dplyr::collect()
 
 logger::log_info("Dataset collection from duckplyr completed")
@@ -1868,6 +1870,7 @@ logger::log_info("Pre-cleaning record count: {scales::comma(pre_cleaning_record_
 logger::log_info("Collecting data from duckplyr backend to R memory for advanced cleaning")
 
 continental_us_provider_tibble <- continental_us_providers %>%
+  dplyr::compute() %>%
   dplyr::collect()
 
 assertthat::assert_that(

--- a/R/C-physician_compare_cleaning.R
+++ b/R/C-physician_compare_cleaning.R
@@ -57,7 +57,8 @@ filtered_doctors_data <- payments_tbl %>%
   dplyr::filter(Payment_Amount_Numeric > 1) %>%
   # Sort by the numeric column
   dplyr::arrange(desc(Payment_Amount_Numeric)) %>%
-  # Pull the data into R
+  # Materialize then pull the data into R
+  dplyr::compute() %>%
   dplyr::collect()
 
 View(filtered_doctors_data)

--- a/R/E-Medicare_part_d_prescribers_data_processing.R
+++ b/R/E-Medicare_part_d_prescribers_data_processing.R
@@ -277,7 +277,9 @@ for (i in 1:length(table_names)) {
       dplyr::mutate(year = table_name)
     
     logger::log_info("Collecting processed data from table: {table_name}")
-    processed_data_df <- processed_data %>% collect()
+    processed_data_df <- processed_data %>%
+      dplyr::compute() %>%
+      collect()
     logger::log_info("Collected {nrow(processed_data_df)} rows from {table_name}")
     
     # Store results
@@ -313,6 +315,7 @@ for (npi in npi_list) {
   
   npi_check <- first_processed_table %>%
     dplyr::filter(PRSCRBR_NPI == npi_numeric) %>%
+    dplyr::compute() %>%
     collect() %>%
     as.data.frame()
   
@@ -328,7 +331,10 @@ for (npi in npi_list) {
 # --------------------------------------------------------------------------
 logger::log_info("Creating combined dataframe with clean year values")
 medicare_part_d_prescribers_combined <- lapply(processed_tables, function(tbl) {
-  tbl %>% collect() %>% as.data.frame()
+  tbl %>%
+    dplyr::compute() %>%
+    collect() %>%
+    as.data.frame()
 }) %>%
   dplyr::bind_rows() %>%
   dplyr::mutate(year = stringr::str_extract(year, "DY\\d+")) %>%

--- a/R/Postico_database_pull.R
+++ b/R/Postico_database_pull.R
@@ -92,8 +92,9 @@ nucc_taxonomy_201 <- dplyr::tbl(db_connection, "nucc_taxonomy_201")
 physician_compare_data <- physician_compare_table %>%
   distinct(NPI, .keep_all = TRUE) %>%
   mutate(`Zip Code` = str_sub(`Zip Code`,1 ,5)) %>%
-  filter(`Primary Specialty` %in% c("GYNECOLOGICAL ONCOLOGY", "OBSTETRICS/GYNECOLOGY")) %>% 
+  filter(`Primary Specialty` %in% c("GYNECOLOGICAL ONCOLOGY", "OBSTETRICS/GYNECOLOGY")) %>%
   mutate(year = "2023") %>%
+  dplyr::compute() %>%
   collect()
 
 View(physician_compare_data)

--- a/R/bespoke_functions.R
+++ b/R/bespoke_functions.R
@@ -1510,6 +1510,7 @@ count_nppes_providers <- function(connection, table_name) {
   tryCatch({
     provider_count <- dplyr::tbl(connection, table_name) %>%
       dplyr::count() %>%
+      dplyr::compute() %>%
       dplyr::collect() %>%
       dplyr::pull(n)
     
@@ -1533,6 +1534,7 @@ save_nppes_to_rds <- function(connection, table_name, output_path) {
   tryCatch({
     logger::log_debug("Reading data from DuckDB table: {table_name}")
     nppes_provider_data <- dplyr::tbl(connection, table_name) %>%
+      dplyr::compute() %>%
       dplyr::collect()
     
     logger::log_info("Saving data to RDS file: {output_path}")
@@ -1967,6 +1969,7 @@ try_dplyr_approach <- function(connection, current_table, current_year, taxonomy
       providers_data <- query %>%
         dplyr::rename(!!!rename_cols) %>%
         dplyr::mutate(Year = as.integer(current_year)) %>%
+        dplyr::compute() %>%
         dplyr::collect(n = max_results_per_year)
       
       if ("Zip" %in% colnames(providers_data)) {

--- a/R/physician_compare_data.R
+++ b/R/physician_compare_data.R
@@ -619,6 +619,7 @@ yearly_counts <- tbl(con, "physician_data_standardized") %>%
   group_by(year) %>%
   summarize(count = n()) %>%
   arrange(year) %>%
+  dplyr::compute() %>%
   collect()
 
 print(yearly_counts)

--- a/database_optimization_notes.md
+++ b/database_optimization_notes.md
@@ -22,4 +22,6 @@ The following list summarizes 19 potential optimizations that can help speed up 
 18. **Avoid writing large intermediary CSV files** when they can be stored in DuckDB directly, as seen around line 168 in `zzC-Extracting_and_Processing_NPPES.R`.
 19. **Profile query plans** with `EXPLAIN` in DuckDB to spot slow joins—add optional diagnostics in `R/bespoke_functions.R` before complex queries.
 
+20. **Call `compute()` before `collect()`** to materialize intermediate results in DuckDB, reducing memory use and improving performance when transferring data back into R.
+
 These suggestions target common bottlenecks in reading and writing large datasets. Implementing them can substantially speed up data preparation and analysis.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2025-06-24
+- Added `compute()` before `collect()` in several scripts to ensure heavy queries are materialized in DuckDB prior to transferring results into R.
+
 ## 2025-06-23
 - Documented supporting files in the README and introduced the `count_paragraphs()` helper.
 - Added tests for the new helper function.


### PR DESCRIPTION
## Summary
- materialize duckplyr results with `compute()` before calling `collect()`
- document the `compute()` guideline in the optimization notes
- record the change in the project changelog

## Testing
- `devtools::test()` *(fails: R not available)*

------
https://chatgpt.com/codex/tasks/task_e_68597f70e088832ca53e0c4bedd7b881