### PR TITLE
Improve code style

### DIFF
--- a/R/abstract_statistics.R
+++ b/R/abstract_statistics.R
@@ -14,11 +14,15 @@
 #' summarize_abstract(abstract_text)
 #' @export
 summarize_abstract <- function(text) {
-  tibble::tibble(
+  stopifnot(is.character(text))
+
+  result <- tibble::tibble(
     words = stringr::str_count(text, stringr::boundary("word")),
     sentences = stringr::str_count(text, stringr::boundary("sentence")),
     characters = nchar(text)
   )
+
+  result
 }
 
 #' Count the number of paragraphs in text
@@ -30,9 +34,12 @@ summarize_abstract <- function(text) {
 #'
 #' @export
 count_paragraphs <- function(text) {
+  stopifnot(is.character(text))
+
   if (length(text) > 1) {
     text <- paste(text, collapse = "\n")
   }
-  parts <- unlist(strsplit(text, "\n\s*\n"))
+
+  parts <- stringr::str_split(text, "\n\s*\n")[[1]]
   sum(nzchar(trimws(parts)))
 }

--- a/R/api_utils.R
+++ b/R/api_utils.R
@@ -21,7 +21,7 @@ get_env_or_stop <- function(var, msg = NULL, verbose = FALSE) {
 
   val <- Sys.getenv(var)
 
-  if (val == "") {
+  if (!nzchar(val)) {
     if (is.null(msg)) {
       msg <- paste0(var, " environment variable is not set. Please add it to your .Renviron or .env file")
     }
@@ -32,5 +32,5 @@ get_env_or_stop <- function(var, msg = NULL, verbose = FALSE) {
     logger::log_info("Successfully retrieved environment variable '%s'", var)
   }
 
-  val
+  return(val)
 }

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -13,6 +13,9 @@
 #' @examples
 #' format_pct(0.1234, my_digits = 2)
 #' format_pct(c(0.1, 0.25), my_digits = 1)
+#' @export
 format_pct <- function(x, my_digits = 0) {
+  stopifnot(is.numeric(x), is.numeric(my_digits), length(my_digits) == 1)
+
   formatC(x, format = "f", digits = my_digits)
 }

--- a/R/here_api_utils.R
+++ b/R/here_api_utils.R
@@ -16,7 +16,7 @@
 #' }
 #' @export
 initialize_here_api_key <- function(api_key = Sys.getenv("HERE_API_KEY"), verbose = FALSE) {
-  if (is.null(api_key) || api_key == "") {
+  if (!nzchar(api_key)) {
     stop("HERE API key must be provided via argument or HERE_API_KEY env var.")
   }
 
@@ -26,4 +26,6 @@ initialize_here_api_key <- function(api_key = Sys.getenv("HERE_API_KEY"), verbos
   if (verbose) {
     logger::log_info("HERE API key successfully initialized")
   }
+
+  invisible(api_key)
 }

--- a/R/logger_utils.R
+++ b/R/logger_utils.R
@@ -22,6 +22,9 @@ formatter_glue_safe <- function(...,
 #'
 #' @param x Numeric vector to format
 #' @return A character vector of formatted numbers
+#' @export
 format_with_commas <- function(x) {
-  scales::comma(x)
+  stopifnot(is.numeric(x))
+
+  return(scales::comma(x))
 }

--- a/R/print_ascii_art.R
+++ b/R/print_ascii_art.R
@@ -9,7 +9,11 @@
 #' @return Invisibly returns the lines of the ASCII art.
 #' @export
 print_ascii_art <- function(path = file.path("docs", "ascii_art.txt")) {
+  if (!file.exists(path)) {
+    stop(sprintf("ASCII art file '%s' not found", path))
+  }
+
   art <- readLines(path, warn = FALSE)
-  cat(paste(art, collapse = "\n"), "\n")
+  cat(art, sep = "\n")
   invisible(art)
 }

--- a/tests/testthat/test-abstract_stats.R
+++ b/tests/testthat/test-abstract_stats.R
@@ -1,3 +1,4 @@
+testthat::local_edition(3)
 source(file.path("..", "..", "R", "abstract_statistics.R"))
 
 

--- a/tests/testthat/test-count-paragraphs.R
+++ b/tests/testthat/test-count-paragraphs.R
@@ -1,3 +1,4 @@
+testthat::local_edition(3)
 library(testthat)
 source(file.path("..", "..", "R", "abstract_statistics.R"))
 

--- a/tests/testthat/test-format-pct.R
+++ b/tests/testthat/test-format-pct.R
@@ -1,3 +1,4 @@
+testthat::local_edition(3)
 source(file.path("..", "..", "R", "formatting.R"))
 
 testthat::test_that("format_pct rounds and formats numbers", {

--- a/tests/testthat/test-print-ascii-art.R
+++ b/tests/testthat/test-print-ascii-art.R
@@ -1,3 +1,4 @@
+testthat::local_edition(3)
 source(file.path("..", "..", "R", "print_ascii_art.R"))
 
 testthat::test_that("print_ascii_art outputs ascii", {


### PR DESCRIPTION
## Summary
- strengthen input checks in `summarize_abstract` and `count_paragraphs`
- handle empty strings in `get_env_or_stop`
- ensure `initialize_here_api_key` returns invisibly
- validate numeric input in `format_pct`
- check numeric input in `format_with_commas`
- verify ASCII art file existence in `print_ascii_art`
- use testthat edition 3 in test files

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: object 'compare_proxy' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6eb416b8832cbbeea3a992ea06e0