### PR TITLE
Update NEWS and fix escape string

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # News
+## 2025-06-28
+Refined file names for consistency, added a `CITATION.MD` file, and improved code style across functions and tests.
 
 ## 2025-06-27
 The project now standardizes address data with the `postmastr` package, greatly improving downstream geocoding. Roxygen documentation has been expanded across helper files and additional comments in `01-setup.R` explain the purpose of each library.

--- a/R/abstract_statistics.R
+++ b/R/abstract_statistics.R
@@ -40,6 +40,6 @@ count_paragraphs <- function(text) {
     text <- paste(text, collapse = "\n")
   }
 
-  parts <- stringr::str_split(text, "\n\s*\n")[[1]]
+  parts <- stringr::str_split(text, "\\n\\s*\\n")[[1]]
   sum(nzchar(trimws(parts)))
 }


### PR DESCRIPTION
## Summary
- add 2025-06-28 entry to NEWS
- escape regex in `abstract_statistics.R`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: package tibble not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865eff73834832cb026cb35905733df