### PR TITLE
Integrate output helpers in GO access analysis

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,3 +8,8 @@ importFrom(tibble, as_tibble)
 export(summarize_abstract)
 export(count_paragraphs)
 export(print_ascii_art)
+
+export(create_output_structure)
+export(save_intermediate_result)
+export(prepare_visualization_data)
+importFrom(sf, st_write)

--- a/R/GO_access_analysis_code.Rmd
+++ b/R/GO_access_analysis_code.Rmd
@@ -104,6 +104,7 @@ library(tigris)
 
 # Statistical analysis
 library(stats)
+library(isochrones)
 
 # Set logger threshold
 logger::log_threshold(params$log_level)
@@ -147,7 +148,8 @@ setup_figure_directories <- function(base_dir = "figures") {
 }
 
 # Run this first
-figures_dir <- setup_figure_directories(params$figure_base_dir)
+output_dirs <- create_output_structure(params$figure_base_dir)
+figures_dir <- setup_figure_directories(output_dirs$visualization)
 ```
 
 ```{r constants, include=FALSE}
@@ -4525,6 +4527,9 @@ isos <- sf::st_read("/Users/tylermuffly/Dropbox (Personal)/walker_maps/data/2024
 #isos <- st_read("data/HERE_isochrone_results (1)/20241013161700.shp") %>%
   mutate(year = str_sub(departure, 1, 4))
 
+# Save full isochrone dataset for interactive visualization
+prepare_visualization_data(isos, output_dirs, "all_isochrones.geojson")
+
 # Let's make a list of isochrone maps, named by year. Styling can be modified as needed.
 years <- 2013:2023
 names(years) <- paste0("y", years)
@@ -4692,11 +4697,9 @@ hybrid_statistical_implementation <- function(accessibility_data_path = params$i
   logger::log_info("Using feasible methods only - no complex spatial analysis")
   logger::log_info("Confidence level: {confidence_level}")
   
-  # Create output directory
-  if (!dir.exists(results_output_directory)) {
-    dir.create(results_output_directory, recursive = TRUE)
-    logger::log_info("Created output directory: {results_output_directory}")
-  }
+  # Create output directory structure
+  output_paths <- create_output_structure(results_output_directory)
+  logger::log_info("Output base directory: {output_paths$base}")
   
   # Read and process data
   logger::log_info("Reading accessibility data")
@@ -5164,9 +5167,10 @@ hybrid_statistical_implementation <- function(accessibility_data_path = params$i
   comprehensive_results$methods_compliance_summary <- methods_compliance_summary
   
   # Save methods compliance summary
-  saveRDS(
-    methods_compliance_summary, 
-    file.path(results_output_directory, "methods_compliance_summary.rds")
+  save_intermediate_result(
+    methods_compliance_summary,
+    "methods_compliance_summary",
+    output_paths
   )
   
   logger::log_info("Hybrid statistical implementation complete")

--- a/R/output_structure.R
+++ b/R/output_structure.R
@@ -1,0 +1,53 @@
+#' Setup Output Structure
+#'
+#' Create structured directories for intermediate and visualization outputs.
+#'
+#' @param base_path Base path for output directories. Defaults to "output".
+#' @return Named list with created directory paths.
+#' @export
+create_output_structure <- function(base_path = "output") {
+  dirs <- list(
+    base = base_path,
+    intermediate = file.path(base_path, "intermediate"),
+    visualization = file.path(base_path, "visualization")
+  )
+
+  for (d in dirs) {
+    if (!dir.exists(d)) {
+      dir.create(d, recursive = TRUE, showWarnings = FALSE)
+    }
+  }
+  return(dirs)
+}
+
+#' Save Intermediate Result
+#'
+#' Save an R object as an RDS file inside the intermediate directory.
+#'
+#' @param object R object to save.
+#' @param name File name without extension.
+#' @param paths List returned by `create_output_structure`.
+#' @return File path of the saved object.
+#' @export
+save_intermediate_result <- function(object, name, paths) {
+  stopifnot("intermediate" %in% names(paths))
+  file_path <- file.path(paths$intermediate, paste0(name, ".rds"))
+  saveRDS(object, file_path)
+  return(file_path)
+}
+
+#' Prepare Visualization Ready Data
+#'
+#' Write an `sf` object to GeoJSON for easy visualization.
+#'
+#' @param sf_object An `sf` object.
+#' @param paths List returned by `create_output_structure`.
+#' @param file_name Name of the GeoJSON file. Defaults to "visualization_data.geojson".
+#' @return File path of the saved GeoJSON.
+#' @export
+prepare_visualization_data <- function(sf_object, paths, file_name = "visualization_data.geojson") {
+  stopifnot("visualization" %in% names(paths))
+  file_path <- file.path(paths$visualization, file_name)
+  sf::st_write(sf_object, file_path, driver = "GeoJSON", append = FALSE, quiet = TRUE)
+  return(file_path)
+}

--- a/tests/testthat/test-output-structure.R
+++ b/tests/testthat/test-output-structure.R
@@ -1,0 +1,29 @@
+testthat::local_edition(3)
+source(file.path("..", "..", "R", "output_structure.R"))
+
+
+testthat::test_that("create_output_structure creates directories", {
+  tmp <- tempfile()
+  paths <- create_output_structure(tmp)
+  testthat::expect_true(dir.exists(paths$intermediate))
+  testthat::expect_true(dir.exists(paths$visualization))
+})
+
+
+testthat::test_that("save_intermediate_result writes file", {
+  tmp <- tempfile()
+  paths <- create_output_structure(tmp)
+  f <- save_intermediate_result(mtcars, "mt", paths)
+  testthat::expect_true(file.exists(f))
+})
+
+
+testthat::test_that("prepare_visualization_data writes geojson", {
+  testthat::skip_if_not_installed("sf")
+  library(sf)
+  tmp <- tempfile()
+  paths <- create_output_structure(tmp)
+  sf_obj <- st_as_sf(data.frame(id = 1, geometry = st_sfc(st_point(c(0,0)))), crs = 4326)
+  out <- prepare_visualization_data(sf_obj, paths, "file.geojson")
+  testthat::expect_true(file.exists(out))
+})


### PR DESCRIPTION
## Summary
- use `create_output_structure` when preparing figure directories
- export isochrones to GeoJSON via `prepare_visualization_data`
- save methods summary using `save_intermediate_result`
- load package in the analysis document

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686705ae7814832c92c94dca8c15ebc0